### PR TITLE
Fix to typecheck in 6.1.1

### DIFF
--- a/ebml/reader.rkt
+++ b/ebml/reader.rkt
@@ -63,7 +63,7 @@
 
 (: optimistic-parse : Input-Port (U #f Bytes) -> (U Bytes (Listof Element)))
 (define (optimistic-parse port fallback-bytes)
-  (with-handlers ([exn:fail? (lambda (exn) 
+  (with-handlers ([exn:fail? (lambda ([exn : exn:fail]) 
                                (or fallback-bytes
                                    (raise exn)))])
     (define sub-elements (ebml-read port))


### PR DESCRIPTION
`raise` now requires a more specific type.