### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/ebml/ebml.scrbl
+++ b/ebml/ebml.scrbl
@@ -2,7 +2,7 @@
 
 @(require scribble/manual)
 
-@title{@bold{EBML}: A binary encoding format}
+@title{EBML: A binary encoding format}
 
 @author[(author+email "John Clements" "clements@racket-lang.org")]
 


### PR DESCRIPTION
For visual consistency with other packages within the docs